### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==1.11
+django-bootstrap3==9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Django==1.11
-django-bootstrap3==9.0
+Django>=1.11,<1.12
+django-bootstrap3>=9.0,<9.1
+djangorestframework>=3.6,<3.7


### PR DESCRIPTION
The fix-requirements branch forces pip to lock on a major version e.g. Django 1.11 without worrying about minor versions e.g. Django 1.11.6. Now rebased onto new master, unlike #18.